### PR TITLE
Added cancellation token.

### DIFF
--- a/step06_redis/code/Cargo.toml
+++ b/step06_redis/code/Cargo.toml
@@ -9,3 +9,4 @@ tokio = { version = "1", features = ["full"] }
 anyhow = "1.0"
 chrono = "0.4"
 futures = "0.3"
+tokio-util = "0.7.14"

--- a/step06_redis/code/src/main.rs
+++ b/step06_redis/code/src/main.rs
@@ -7,6 +7,7 @@ use redis::AsyncCommands;
 use std::process::ExitCode;
 use tokio::select;
 use tokio::time::{Duration, sleep};
+use tokio_util::sync::CancellationToken;
 
 #[derive(Parser)]
 struct Args {
@@ -63,16 +64,31 @@ async fn try_sub(args: &Args) -> Result<()> {
     }
   };
 
-  let mut optionally_publish = async || {
-    if let Some(delay) = args.and_publish_in_seconds {
-      sleep(Duration::from_secs_f64(delay)).await;
-      println!("publishing from rust from a separate green thread");
-      con.publish::<_, _, ()>("redis_channel", "published from rust after a delay").await.unwrap()
-    }
-    std::future::pending::<()>().await
-  };
+  let cancel_token = CancellationToken::new();
+  let cloned_token = cancel_token.clone();
+  let sleed_duration = args.subscribe_for_seconds;
+  tokio::spawn(async move {
+    sleep(Duration::from_secs_f64(sleed_duration)).await;
+    cloned_token.cancel();
+  });  
 
-  let timeout = async || sleep(Duration::from_secs_f64(args.subscribe_for_seconds)).await;
+  if let Some(delay) = args.and_publish_in_seconds {
+    let cloned_token = cancel_token.clone();
+    tokio::spawn(async move {
+      select! {
+        _ = async move {
+          sleep(Duration::from_secs_f64(delay)).await;
+          println!("publishing from rust from a separate green thread");
+          con.publish::<_, _, ()>("redis_channel", "published from rust after a delay").await.unwrap();
+        } => {
+          println!("publishing from rust from a separate green thread finished");
+        },
+        _ = cloned_token.cancelled() => {
+          println!("terminating publishing task by cancellationtoken");
+        },
+      }
+    });
+  };
 
   println!("listening to messages on `redis_channel`");
 
@@ -81,10 +97,7 @@ async fn try_sub(args: &Args) -> Result<()> {
       println!("terminating because the pubsub channel is closed");
       Ok(())
     },
-      _ = optionally_publish() => {
-        unreachable!()
-      }
-    _ = timeout() => {
+    _ = cancel_token.cancelled() => {
       println!("terminating by timeout");
       Ok(())
     },

--- a/step06_redis/code/src/main.rs
+++ b/step06_redis/code/src/main.rs
@@ -76,20 +76,18 @@ async fn try_sub(args: &Args) -> Result<()> {
 
   println!("listening to messages on `redis_channel`");
 
-  loop {
-    select! {
-      _ = listen() => {
-        println!("terminating because the pubsub channel is closed");
-        break Ok(())
-      },
+  select! {
+    _ = listen() => {
+      println!("terminating because the pubsub channel is closed");
+      Ok(())
+    },
       _ = optionally_publish() => {
         unreachable!()
       }
-      _ = timeout() => {
-        println!("terminating by timeout");
-        break Ok(())
-      },
-    }
+    _ = timeout() => {
+      println!("terminating by timeout");
+      Ok(())
+    },
   }
 }
 


### PR DESCRIPTION
Now publishing task (or any other task) can be gracefully cancelled from anywhere using token.
Added some prints to show what happens if timeout finishes before publishing.